### PR TITLE
Show git hash + version in sidebar

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from 'next';
+import { execSync } from 'child_process';
+
+// Safe: hardcoded command, no user input — runs at build time only
+const gitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const nextConfig: NextConfig = {
   // node-pty is native and must not be bundled by webpack
   serverExternalPackages: ['node-pty'],
+  env: {
+    NEXT_PUBLIC_GIT_HASH: gitHash,
+  },
 };
 
 export default nextConfig;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -174,6 +174,10 @@ export default function Home() {
           onRefresh={() => setRefreshKey((k) => k + 1)}
         />
       </div>
+      {/* Build version */}
+      <div className="px-4 py-2 border-t border-border text-[10px] text-muted font-mono">
+        v1.0.0 · {process.env.NEXT_PUBLIC_GIT_HASH ?? 'dev'}
+      </div>
     </>
   );
 


### PR DESCRIPTION
## Summary
- Bake `git rev-parse --short HEAD` into `NEXT_PUBLIC_GIT_HASH` at build time via `next.config.ts`
- Display `v1.0.0 · <hash>` at bottom of sidebar footer
- Quick way to verify which build is running on any device

## Files
- `web/next.config.ts` — inject git hash as env var
- `web/src/app/page.tsx` — render version in sidebar

## Test plan
- [ ] Sidebar shows version string with correct git hash
- [ ] Hash updates on rebuild after new commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)