### PR TITLE
feat: add session rename via double-click

### DIFF
--- a/web/src/app/api/sessions/route.ts
+++ b/web/src/app/api/sessions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { listSessionsWithInfo, newSession, killSession } from '@/lib/tmux';
+import { listSessionsWithInfo, newSession, killSession, renameSession } from '@/lib/tmux';
 
 export async function GET() {
   const sessions = await listSessionsWithInfo();
@@ -16,6 +16,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Failed to create session';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const { oldName, newName } = await req.json();
+  if (!oldName || !newName || typeof oldName !== 'string' || typeof newName !== 'string') {
+    return NextResponse.json({ error: 'oldName and newName are required' }, { status: 400 });
+  }
+  try {
+    await renameSession(oldName, newName);
+    return NextResponse.json({ ok: true });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Failed to rename session';
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -120,6 +120,11 @@ export default function Home() {
     return () => navigator.serviceWorker?.removeEventListener('message', onMessage);
   }, [attachSession]);
 
+  const renameSession = useCallback((oldName: string, newName: string) => {
+    setOpenTabs((prev) => prev.map((t) => (t === oldName ? newName : t)));
+    setActiveTab((prev) => (prev === oldName ? newName : prev));
+  }, []);
+
   const detachSession = useCallback((name: string) => {
     setOpenTabs((prev) => {
       const next = prev.filter((t) => t !== name);
@@ -208,6 +213,7 @@ export default function Home() {
           onDetach={detachSession}
           onRefresh={() => setRefreshKey((k) => k + 1)}
           onNewInDir={(dir) => { setNewSessionDir(dir); setShowNewDialog(true); }}
+          onRename={renameSession}
         />
       </div>
       {/* Build version — tap to force reload */}
@@ -322,6 +328,7 @@ export default function Home() {
                   onAttach={attachSession}
                   onDetach={detachSession}
                   onRefresh={() => setRefreshKey((k) => k + 1)}
+                  onRename={renameSession}
                 />
               </div>
             </div>

--- a/web/src/lib/tmux.ts
+++ b/web/src/lib/tmux.ts
@@ -101,6 +101,15 @@ export async function newSession(
   await execFileAsync('tmux', args);
 }
 
+export async function renameSession(
+  oldName: string,
+  newName: string
+): Promise<void> {
+  validateSessionName(oldName);
+  validateSessionName(newName);
+  await execFileAsync('tmux', ['rename-session', '-t', oldName, newName]);
+}
+
 export async function killSession(name: string): Promise<void> {
   validateSessionName(name);
   await execFileAsync('tmux', ['kill-session', '-t', name]);


### PR DESCRIPTION
## Summary
- Add inline rename for tmux sessions — double-click a session name in the sidebar to edit it
- New `PATCH /api/sessions` endpoint wrapping `tmux rename-session`
- Open tabs and active tab references update automatically on rename

## Test Plan
- [x] Next.js production build passes
- [ ] Double-click session name → inline input appears
- [ ] Enter confirms rename, Escape cancels, click-away confirms
- [ ] Invalid names (spaces, special chars) are rejected silently
- [ ] Renaming an open tab updates the tab reference and URL param

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)