### PR TITLE
Make claude-wormhole user-agnostic with installer cleanup

### DIFF
--- a/bin/wormhole
+++ b/bin/wormhole
@@ -201,7 +201,9 @@ cmd_service() {
       (cd "$WORMHOLE_ROOT" && npm run build)
 
       log "Installing plist..."
-      cp "$plist_src" "$plist_dst"
+      # Expand template placeholders with this user's actual paths
+      sed -e "s|__WORMHOLE_ROOT__|$WORMHOLE_ROOT|g" \
+          "$plist_src" > "$plist_dst"
 
       if command -v tailscale &>/dev/null; then
         tailscale serve --bg --https "$WORMHOLE_PORT" "$WORMHOLE_PORT" 2>/dev/null || warn "Tailscale serve failed"

--- a/scripts/com.claude-wormhole.web.plist
+++ b/scripts/com.claude-wormhole.web.plist
@@ -6,11 +6,11 @@
     <string>com.claude-wormhole.web</string>
 
     <key>WorkingDirectory</key>
-    <string>/Users/shyam/www/claude-wormhole</string>
+    <string>__WORMHOLE_ROOT__</string>
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/shyam/www/claude-wormhole/bin/wormhole</string>
+        <string>__WORMHOLE_ROOT__/bin/wormhole</string>
         <string>start</string>
     </array>
 
@@ -18,8 +18,6 @@
     <dict>
         <key>NODE_ENV</key>
         <string>production</string>
-        <key>TZ</key>
-        <string>Asia/Calcutta</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/scripts/statusline-test.sh
+++ b/scripts/statusline-test.sh
@@ -98,7 +98,7 @@ run_ansi_test() {
 
 FULL_JSON='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 1.23, "total_duration_ms": 492000, "total_api_duration_ms": 12000, "total_lines_added": 156, "total_lines_removed": 23},
   "context_window": {"total_input_tokens": 84000, "total_output_tokens": 4521, "context_window_size": 200000, "used_percentage": 42, "remaining_percentage": 58},
   "session_id": "abc123", "version": "1.0.80"
@@ -106,7 +106,7 @@ FULL_JSON='{
 
 EARLY_SESSION='{
   "model": {"id": "claude-sonnet-4-5-20250929", "display_name": "Sonnet"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": null, "total_duration_ms": null, "total_lines_added": null, "total_lines_removed": null},
   "context_window": {"used_percentage": null, "remaining_percentage": null, "current_usage": null},
   "session_id": "def456", "version": "1.0.80"
@@ -122,7 +122,7 @@ HIGH_CONTEXT='{
 
 CRITICAL_CONTEXT='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 12.34, "total_duration_ms": 3600000, "total_lines_added": 500, "total_lines_removed": 200},
   "context_window": {"used_percentage": 95, "remaining_percentage": 5},
   "session_id": "jkl012", "version": "1.0.80"
@@ -130,7 +130,7 @@ CRITICAL_CONTEXT='{
 
 ZERO_CONTEXT='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 0, "total_duration_ms": 0, "total_lines_added": 0, "total_lines_removed": 0},
   "context_window": {"used_percentage": 0, "remaining_percentage": 100},
   "session_id": "mno345", "version": "1.0.80"
@@ -138,7 +138,7 @@ ZERO_CONTEXT='{
 
 FULL_CONTEXT='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 25.00, "total_duration_ms": 7200000, "total_lines_added": 1000, "total_lines_removed": 500},
   "context_window": {"used_percentage": 100, "remaining_percentage": 0},
   "session_id": "pqr678", "version": "1.0.80"
@@ -146,7 +146,7 @@ FULL_CONTEXT='{
 
 DECIMAL_PCT='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 0.50, "total_duration_ms": 120000, "total_lines_added": 10, "total_lines_removed": 3},
   "context_window": {"used_percentage": 42.7, "remaining_percentage": 57.3},
   "session_id": "stu901", "version": "1.0.80"
@@ -159,7 +159,7 @@ MINIMAL_JSON='{
 
 SONNET_MODEL='{
   "model": {"id": "claude-sonnet-4-5-20250929", "display_name": "Sonnet"},
-  "workspace": {"current_dir": "/Users/shyam/www/reels_new", "project_dir": "/Users/shyam/www/reels_new"},
+  "workspace": {"current_dir": "/home/user/projects/reels_new", "project_dir": "/home/user/projects/reels_new"},
   "cost": {"total_cost_usd": 0.08, "total_duration_ms": 60000, "total_lines_added": 20, "total_lines_removed": 5},
   "context_window": {"used_percentage": 12, "remaining_percentage": 88},
   "session_id": "vwx234", "version": "1.0.80"
@@ -167,7 +167,7 @@ SONNET_MODEL='{
 
 HIGH_COST='{
   "model": {"id": "claude-opus-4-6", "display_name": "Opus"},
-  "workspace": {"current_dir": "/Users/shyam/www/claude-wormhole", "project_dir": "/Users/shyam/www/claude-wormhole"},
+  "workspace": {"current_dir": "/home/user/projects/claude-wormhole", "project_dir": "/home/user/projects/claude-wormhole"},
   "cost": {"total_cost_usd": 123.45, "total_duration_ms": 18000000, "total_lines_added": 2000, "total_lines_removed": 800},
   "context_window": {"used_percentage": 65, "remaining_percentage": 35},
   "session_id": "yza567", "version": "1.0.80"

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'http';
-import { closeSync } from 'fs';
+import { closeSync, existsSync } from 'fs';
 import { parse } from 'url';
 import { execFileSync } from 'child_process';
 import next from 'next';
@@ -67,11 +67,13 @@ app.prepare().then(() => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const pty = require('node-pty');
 
-    // Build env with proper PATH for homebrew
+    // Build env with proper PATH for homebrew (Apple Silicon + Intel Mac)
     // Explicit type preserves the string index signature from process.env
     const env: Record<string, string | undefined> = { ...process.env, TERM: 'xterm-256color' };
-    if (!env.PATH?.includes('/opt/homebrew/bin')) {
-      env.PATH = `/opt/homebrew/bin:${env.PATH}`;
+    for (const dir of ['/opt/homebrew/bin', '/usr/local/bin']) {
+      if (existsSync(dir) && !env.PATH?.includes(dir)) {
+        env.PATH = `${dir}:${env.PATH}`;
+      }
     }
 
     let ptyProcess: ReturnType<typeof pty.spawn>;


### PR DESCRIPTION
## Summary
- Convert plist to template with placeholder tokens, expanded at install time via `sed`
- Add installer cleanup step that removes old scripts, stale plist, stale symlinks, and auto-upgrades old Claude hook references
- Fix Homebrew path detection in server.ts to work on both Apple Silicon and Intel Macs
- Replace all hardcoded paths and user-specific assumptions with dynamic resolution

## Test Plan
- Ran sandboxed install test with `HOME=/tmp/wormhole-test` to verify all files created correctly
- Tested cleanup of old artifacts (stale plist with `/Users/` paths, old `scripts/notify.sh` hooks)
- Verified hook auto-upgrade from `scripts/notify.sh` -> `bin/wormhole notify`
- All 27 statusline tests pass
- Clean `npm run build` compiles
- Server healthy after real reinstall

Closes #31