### PR TITLE
test: add Playwright WebKit tests for mobile terminal interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 .env.local
 data/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ws": "^8.18.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -1150,6 +1151,23 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2237,6 +2255,53 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "next build && npm run build:server",
     "prestart": "test -f dist/server.cjs || (echo 'Run npm run build first' && exit 1)",
     "start": "NODE_ENV=production node dist/server.cjs",
-    "setup:push": "./bin/wormhole setup push"
+    "setup:push": "./bin/wormhole setup push",
+    "test": "npx playwright test --config tests/playwright.config.ts",
+    "test:mobile": "npx playwright test --config tests/playwright.config.ts --project mobile-webkit",
+    "test:mobile:headed": "npx playwright test --config tests/playwright.config.ts --project mobile-webkit --headed"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -25,6 +28,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -646,7 +646,7 @@ export function TerminalView({
         reconnectTimerRef.current = null;
       }
       wsRef.current?.close();
-      cleanup.then((fn) => fn?.());
+      cleanup.then((fn) => fn?.()).catch(() => {/* cleanup errors non-fatal on unmount */});
     };
     // theme intentionally excluded — handled by separate effect
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tests/fixtures/sessions.json
+++ b/tests/fixtures/sessions.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "claude-dev",
+    "windows": 1,
+    "attached": true,
+    "created": "2/20/2026, 10:00:00 AM",
+    "workingDir": "/home/user/projects/claude-wormhole",
+    "lastActivity": "just now",
+    "claudeHint": "idle"
+  },
+  {
+    "name": "notes",
+    "windows": 1,
+    "attached": false,
+    "created": "2/20/2026, 9:00:00 AM",
+    "workingDir": "/home/user/notes",
+    "lastActivity": "5m ago",
+    "claudeHint": null
+  }
+]

--- a/tests/helpers/terminal.ts
+++ b/tests/helpers/terminal.ts
@@ -1,0 +1,351 @@
+import type { Page, Route } from '@playwright/test';
+import sessionsFixture from '../fixtures/sessions.json';
+
+/**
+ * Messages captured from client → server on the mocked WebSocket.
+ * Each entry is the raw string the app sent via ws.send().
+ */
+export type WsMessages = string[];
+
+/**
+ * Set up route mocks for /api/sessions and the WebSocket at /api/terminal.
+ * Returns an array that accumulates all WS messages sent by the client.
+ */
+export async function setupTerminalMocks(
+  page: Page,
+  opts: { enableMouseTracking?: boolean } = {}
+): Promise<WsMessages> {
+  const { enableMouseTracking = false } = opts;
+  const sent: WsMessages = [];
+
+  // Mock /api/sessions — return fixture data
+  await page.route('**/api/sessions', (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(sessionsFixture),
+    });
+  });
+
+  // Mock WebSocket at /api/terminal
+  // page.routeWebSocket intercepts the WS upgrade and gives us a mock server
+  await page.routeWebSocket(/\/api\/terminal/, (ws) => {
+    // Capture every message the client sends (only strings expected)
+    ws.onMessage((msg) => {
+      if (typeof msg !== 'string') {
+        throw new Error(`Unexpected binary WS frame: ${Buffer.from(msg).toString('hex')}`);
+      }
+      sent.push(msg);
+    });
+
+    // Send a welcome banner so the terminal renders something.
+    // onMessage handler fires synchronously after connection, but xterm.js
+    // needs a microtask to attach its data listener — queueMicrotask bridges that gap
+    // without introducing the flakiness of a fixed setTimeout.
+    queueMicrotask(() => {
+      if (enableMouseTracking) {
+        // Enable VT200 mouse tracking + SGR encoding so xterm.js enters
+        // a mouse tracking mode (required for selection mode to activate)
+        ws.send('\x1b[?1000h\x1b[?1006h');
+      }
+      ws.send('Welcome to mock terminal\r\n$ ');
+    });
+  });
+
+  return sent;
+}
+
+/**
+ * Navigate to the terminal page for a given session.
+ * Waits for the terminal container to be visible.
+ */
+export async function openTerminalSession(
+  page: Page,
+  sessionName = 'claude-dev'
+): Promise<void> {
+  await page.goto(`/?session=${sessionName}`);
+  // Wait for the xterm terminal to render
+  await page.waitForSelector('.xterm-screen', { timeout: 10_000 });
+}
+
+/**
+ * Trigger a pointerdown event on a button (for React onPointerDown handlers).
+ * Playwright's dispatchEvent creates a basic Event — we need a real PointerEvent.
+ */
+export async function pointerDown(page: Page, selector: string): Promise<void> {
+  await page.locator(selector).evaluate((el) => {
+    el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
+  });
+}
+
+/**
+ * Inject WebKit-compatible touch helper functions into the page.
+ * Called once per test via addInitScript — avoids duplicating makeTouch/makeTouchList
+ * in every page.evaluate() call.
+ */
+export async function injectTouchHelpers(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // WebKit doesn't support `new Touch()` constructor, so we fall back to
+    // document.createTouch/createTouchList (deprecated but functional in WebKit).
+    (window as any).__makeTouch = (el: Element, x: number, y: number): Touch => {
+      try {
+        return new Touch({ identifier: 1, target: el, clientX: x, clientY: y });
+      } catch {
+        return (document as any).createTouch(window, el, 1, x, y, x, y);
+      }
+    };
+
+    (window as any).__makeTouchList = (...touches: Touch[]): TouchList => {
+      try {
+        if (typeof (document as any).createTouchList === 'function') {
+          return (document as any).createTouchList(...touches);
+        }
+      } catch { /* fall through */ }
+      // Polyfill: array-like with item() method
+      const list = [...touches] as any;
+      list.item = (i: number) => touches[i] || null;
+      return list as TouchList;
+    };
+  });
+}
+
+/**
+ * Get the .xterm-screen element, throwing if not found.
+ * Used internally by touch dispatch helpers.
+ */
+function getXtermScreenScript(): string {
+  return `const el = document.querySelector('.xterm-screen'); if (!el) throw new Error('Terminal .xterm-screen not found');`;
+}
+
+/**
+ * Dispatch touch events using WebKit-compatible approach.
+ * Requires injectTouchHelpers() to have been called (via stubBrowserAPIs).
+ */
+export async function dispatchTouchSequence(
+  page: Page,
+  opts: {
+    /** Array of [clientX, clientY] pairs: first = touchstart position, rest = touchmove, last auto-generates touchend */
+    points: [number, number][];
+    /** Delay in ms between each move event (default 0) */
+    moveDelay?: number;
+  }
+): Promise<void> {
+  const { points, moveDelay = 0 } = opts;
+  if (points.length < 1) throw new Error('Need at least 1 point');
+
+  await page.evaluate(
+    ({ pts, delay }) => {
+      return new Promise<void>((resolve) => {
+        const el = document.querySelector('.xterm-screen');
+        if (!el) throw new Error('Terminal .xterm-screen not found');
+
+        const makeTouch = (window as any).__makeTouch.bind(null, el);
+        const makeTouchList = (window as any).__makeTouchList;
+
+        const [startX, startY] = pts[0];
+        const startTouch = makeTouch(startX, startY);
+
+        el.dispatchEvent(new TouchEvent('touchstart', {
+          bubbles: true,
+          cancelable: true,
+          touches: makeTouchList(startTouch),
+          targetTouches: makeTouchList(startTouch),
+          changedTouches: makeTouchList(startTouch),
+        }));
+
+        let i = 1;
+        function nextMove() {
+          if (i >= pts.length) {
+            // touchend with last position
+            const [ex, ey] = pts[pts.length - 1];
+            const endTouch = makeTouch(ex, ey);
+            el!.dispatchEvent(new TouchEvent('touchend', {
+              bubbles: true,
+              cancelable: true,
+              touches: makeTouchList(),
+              targetTouches: makeTouchList(),
+              changedTouches: makeTouchList(endTouch),
+            }));
+            resolve();
+            return;
+          }
+          const [mx, my] = pts[i];
+          const moveTouch = makeTouch(mx, my);
+          el!.dispatchEvent(new TouchEvent('touchmove', {
+            bubbles: true,
+            cancelable: true,
+            touches: makeTouchList(moveTouch),
+            targetTouches: makeTouchList(moveTouch),
+            changedTouches: makeTouchList(moveTouch),
+          }));
+          i++;
+          if (delay > 0) {
+            setTimeout(nextMove, delay);
+          } else {
+            nextMove();
+          }
+        }
+
+        nextMove();
+      });
+    },
+    { pts: points, delay: moveDelay }
+  );
+}
+
+/**
+ * Dispatch only a touchstart (for long-press testing).
+ * Does NOT fire touchend — caller controls timing.
+ */
+export async function dispatchTouchStart(
+  page: Page,
+  x: number,
+  y: number
+): Promise<void> {
+  await page.evaluate(
+    ({ x, y }) => {
+      const el = document.querySelector('.xterm-screen');
+      if (!el) throw new Error('Terminal .xterm-screen not found');
+      const makeTouch = (window as any).__makeTouch.bind(null, el);
+      const makeTouchList = (window as any).__makeTouchList;
+      const t = makeTouch(x, y);
+      el.dispatchEvent(new TouchEvent('touchstart', {
+        bubbles: true, cancelable: true,
+        touches: makeTouchList(t),
+        targetTouches: makeTouchList(t),
+        changedTouches: makeTouchList(t),
+      }));
+    },
+    { x, y }
+  );
+}
+
+/**
+ * Dispatch only a touchend.
+ */
+export async function dispatchTouchEnd(
+  page: Page,
+  x: number,
+  y: number
+): Promise<void> {
+  await page.evaluate(
+    ({ x, y }) => {
+      const el = document.querySelector('.xterm-screen');
+      if (!el) throw new Error('Terminal .xterm-screen not found');
+      const makeTouch = (window as any).__makeTouch.bind(null, el);
+      const makeTouchList = (window as any).__makeTouchList;
+      const t = makeTouch(x, y);
+      el.dispatchEvent(new TouchEvent('touchend', {
+        bubbles: true, cancelable: true,
+        touches: makeTouchList(),
+        targetTouches: makeTouchList(),
+        changedTouches: makeTouchList(t),
+      }));
+    },
+    { x, y }
+  );
+}
+
+/**
+ * Dispatch a touchmove event.
+ */
+export async function dispatchTouchMove(
+  page: Page,
+  x: number,
+  y: number
+): Promise<void> {
+  await page.evaluate(
+    ({ x, y }) => {
+      const el = document.querySelector('.xterm-screen');
+      if (!el) throw new Error('Terminal .xterm-screen not found');
+      const makeTouch = (window as any).__makeTouch.bind(null, el);
+      const makeTouchList = (window as any).__makeTouchList;
+      const t = makeTouch(x, y);
+      el.dispatchEvent(new TouchEvent('touchmove', {
+        bubbles: true, cancelable: true,
+        touches: makeTouchList(t),
+        targetTouches: makeTouchList(t),
+        changedTouches: makeTouchList(t),
+      }));
+    },
+    { x, y }
+  );
+}
+
+/**
+ * Wait briefly for async WS messages to arrive.
+ * NOTE: Uses waitForTimeout because WS message delivery has no observable DOM side-effect
+ * to wait on. Playwright docs discourage this for DOM waits, but it's appropriate for
+ * async message accumulation in a mock WS.
+ */
+export async function waitForMessages(page: Page, ms = 200): Promise<void> {
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Clear the sent messages array (mutates in place).
+ */
+export function clearMessages(messages: WsMessages): void {
+  messages.length = 0;
+}
+
+/**
+ * Stub browser APIs that may not exist in headless: SpeechRecognition, vibrate, etc.
+ * Also injects WebKit-compatible touch helpers (makeTouch/makeTouchList).
+ */
+export async function stubBrowserAPIs(page: Page): Promise<void> {
+  // Inject touch helpers first (used by dispatchTouch* functions)
+  await injectTouchHelpers(page);
+
+  await page.addInitScript(() => {
+    // Track vibrate calls
+    (window as any).__vibrateCalls = [] as number[][];
+    navigator.vibrate = (pattern: VibratePattern) => {
+      const arr = typeof pattern === 'number' ? [pattern] : [...pattern];
+      (window as any).__vibrateCalls.push(arr);
+      return true;
+    };
+
+    // Stub SpeechRecognition
+    class MockSpeechRecognition extends EventTarget {
+      continuous = false;
+      interimResults = false;
+      lang = 'en-US';
+      onresult: ((ev: any) => void) | null = null;
+      onend: (() => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+
+      start() {
+        // Fire onend after a short delay to simulate recognition session
+      }
+      stop() {
+        this.onend?.();
+      }
+      abort() {
+        this.onend?.();
+      }
+    }
+    (window as any).SpeechRecognition = MockSpeechRecognition;
+    (window as any).webkitSpeechRecognition = MockSpeechRecognition;
+
+    // Stub mediaDevices.getUserMedia for mic permission checks.
+    // Returns a minimal MediaStream without creating an AudioContext
+    // (AudioContext can fail or leak in headless environments).
+    if (!navigator.mediaDevices) {
+      (navigator as any).mediaDevices = {};
+    }
+    navigator.mediaDevices.getUserMedia = async () => {
+      return new MediaStream();
+    };
+  });
+}
+
+/**
+ * Get terminal center coordinates.
+ */
+export async function getTerminalCenter(page: Page): Promise<{ cx: number; cy: number }> {
+  const terminal = page.locator('.xterm-screen');
+  const box = await terminal.boundingBox();
+  if (!box) throw new Error('Terminal not visible');
+  return { cx: box.x + box.width / 2, cy: box.y + box.height / 2 };
+}

--- a/tests/mobile/bottom-bar.spec.ts
+++ b/tests/mobile/bottom-bar.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+  pointerDown,
+} from '../helpers/terminal';
+
+test.describe('Bottom bar', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('visible on mobile, hidden on desktop', async ({ page }, testInfo) => {
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    const bottomBar = page.locator('div.md\\:hidden.h-11');
+
+    if (testInfo.project.name === 'mobile-webkit') {
+      await expect(bottomBar).toBeVisible();
+    } else {
+      await expect(bottomBar).toBeHidden();
+    }
+  });
+
+  test('Esc button sends \\x1b', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    // Wait for WS to connect and initial messages to arrive
+    await waitForMessages(page, 500);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Escape"]');
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x1b');
+  });
+
+  test('Enter button sends \\r', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Enter"]');
+    await waitForMessages(page);
+
+    expect(sent).toContain('\r');
+  });
+
+  test('Arrow Up sends \\x1b[A', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Up arrow"]');
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x1b[A');
+  });
+
+  test('Arrow Down sends \\x1b[B', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Down arrow"]');
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x1b[B');
+  });
+
+  test('Exit copy-mode (q) sends q', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Exit copy mode (back to input)"]');
+    await waitForMessages(page);
+
+    expect(sent).toContain('q');
+  });
+
+  test('Keyboard toggle shows/hides virtual keyboard', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    const kbToggle = page.locator('button[title="Show keyboard"]');
+    const kbPanel = page.locator('text=Virtual Keyboard');
+
+    // Initially hidden
+    await expect(kbPanel).toBeHidden();
+
+    // Click toggle → visible
+    await kbToggle.click();
+    await expect(kbPanel).toBeVisible();
+
+    // Click close (X button in keyboard header) → hidden
+    await page.locator('button[title="Hide keyboard"]').click();
+    await expect(kbPanel).toBeHidden();
+  });
+});

--- a/tests/mobile/long-press-selection.spec.ts
+++ b/tests/mobile/long-press-selection.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  stubBrowserAPIs,
+  dispatchTouchStart,
+  dispatchTouchEnd,
+  dispatchTouchMove,
+  getTerminalCenter,
+} from '../helpers/terminal';
+
+test.describe('Long-press selection mode', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('hold 500ms without moving → selection bar appears', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page, { enableMouseTracking: true });
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Simulate long press: touchstart, wait 600ms, touchend
+    await dispatchTouchStart(page, cx, cy);
+    await page.waitForTimeout(600);
+    await dispatchTouchEnd(page, cx, cy);
+    await waitForMessages(page, 200);
+
+    // Selection mode bar should be visible
+    await expect(page.locator('text=Selection mode')).toBeVisible();
+  });
+
+  test('vibrate(50) called on activation', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page, { enableMouseTracking: true });
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    await dispatchTouchStart(page, cx, cy);
+    await page.waitForTimeout(600);
+
+    const vibrateCalls = await page.evaluate(() => (window as any).__vibrateCalls);
+    expect(vibrateCalls).toContainEqual([50]);
+  });
+
+  test('selection mode activates when mouse tracking is enabled', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page, { enableMouseTracking: true });
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // The enterSelectionMode function writes escape sequences to xterm to disable
+    // mouse reporting. We verify the selection bar appears (proving the mode activated).
+    await dispatchTouchStart(page, cx, cy);
+    await page.waitForTimeout(600);
+
+    await expect(page.locator('text=Selection mode')).toBeVisible();
+  });
+
+  test('Done button exits selection mode', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page, { enableMouseTracking: true });
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Enter selection mode
+    await dispatchTouchStart(page, cx, cy);
+    await page.waitForTimeout(600);
+    await dispatchTouchEnd(page, cx, cy);
+    await expect(page.locator('text=Selection mode')).toBeVisible();
+
+    // Tap Done
+    await page.locator('button:has-text("Done")').click();
+    await expect(page.locator('text=Selection mode')).toBeHidden();
+  });
+
+  test('move finger >10px during hold → no selection mode', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page, { enableMouseTracking: true });
+    await openTerminalSession(page);
+    await waitForMessages(page, 500);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Start touch, then move 20px (> 10px threshold) within 200ms
+    await dispatchTouchStart(page, cx, cy);
+    await page.waitForTimeout(200);
+    await dispatchTouchMove(page, cx, cy - 20);
+
+    // Wait past long-press threshold
+    await page.waitForTimeout(500);
+    await dispatchTouchEnd(page, cx, cy - 20);
+
+    // Selection mode should NOT have activated
+    await expect(page.locator('text=Selection mode')).toBeHidden();
+  });
+});

--- a/tests/mobile/paste.spec.ts
+++ b/tests/mobile/paste.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+  pointerDown,
+} from '../helpers/terminal';
+
+test.describe('Paste', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('clipboard has text → sends text over WS', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+
+    // Stub clipboard.readText to return "hello"
+    await page.addInitScript(() => {
+      navigator.clipboard.readText = async () => 'hello';
+    });
+
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Paste (Ctrl+V)"]');
+    await waitForMessages(page, 500);
+
+    expect(sent).toContain('hello');
+  });
+
+  test('clipboard empty → sends Ctrl+V (\\x16)', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+
+    // Stub clipboard.readText to return empty string
+    await page.addInitScript(() => {
+      navigator.clipboard.readText = async () => '';
+    });
+
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Paste (Ctrl+V)"]');
+    await waitForMessages(page, 500);
+
+    expect(sent).toContain('\x16');
+  });
+
+  test('clipboard permission denied → sends Ctrl+V (\\x16)', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+
+    // Stub clipboard.readText to throw (simulating denied permission)
+    await page.addInitScript(() => {
+      navigator.clipboard.readText = async () => {
+        throw new DOMException('Clipboard access denied', 'NotAllowedError');
+      };
+    });
+
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    clearMessages(sent);
+    await pointerDown(page, 'button[title="Paste (Ctrl+V)"]');
+    await waitForMessages(page, 500);
+
+    expect(sent).toContain('\x16');
+  });
+});

--- a/tests/mobile/scroll-fabs.spec.ts
+++ b/tests/mobile/scroll-fabs.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+} from '../helpers/terminal';
+
+test.describe('Scroll FABs', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('FABs visible on mobile, hidden on desktop', async ({ page }, testInfo) => {
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    const fabContainer = page.locator('button[title="Scroll up (tmux)"]');
+
+    if (testInfo.project.name === 'mobile-webkit') {
+      await expect(fabContainer).toBeVisible();
+    } else {
+      await expect(fabContainer).toBeHidden();
+    }
+  });
+
+  test('scroll-up FAB sends tmux copy-mode + PgUp', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    clearMessages(sent);
+    await page.locator('button[title="Scroll up (tmux)"]').click();
+    // Wait 200ms for the setTimeout(100ms) + message delivery
+    await waitForMessages(page, 300);
+
+    // First: tmux prefix + [ to enter copy mode (\x02[)
+    expect(sent).toContain('\x02[');
+    // Then: PgUp (\x1b[5~)
+    expect(sent).toContain('\x1b[5~');
+
+    // Verify order: \x02[ should come before \x1b[5~
+    const copyModeIdx = sent.indexOf('\x02[');
+    const pgUpIdx = sent.indexOf('\x1b[5~');
+    expect(copyModeIdx).toBeLessThan(pgUpIdx);
+  });
+
+  test('scroll-down FAB sends PgDn', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    clearMessages(sent);
+    await page.locator('button[title="Scroll down (tmux)"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x1b[6~');
+  });
+});

--- a/tests/mobile/touch-scroll.spec.ts
+++ b/tests/mobile/touch-scroll.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+  dispatchTouchSequence,
+  getTerminalCenter,
+} from '../helpers/terminal';
+
+test.describe('Touch scroll', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  // Scroll up in tmux = finger moves down (positive clientY delta) = deltaY negative = SGR button 64
+  test('swipe down sends scroll-up SGR sequences', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    clearMessages(sent);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Finger moves DOWN by 60px (3 steps of 20px)
+    await dispatchTouchSequence(page, {
+      points: [
+        [cx, cy],
+        [cx, cy + 20],
+        [cx, cy + 40],
+        [cx, cy + 60],
+      ],
+    });
+
+    await waitForMessages(page, 300);
+
+    // Finger moved down → startY - currentY < 0 → button 64 (scroll up/back in tmux)
+    const scrollUps = sent.filter((m) => m === '\x1b[<64;1;1M');
+    expect(scrollUps.length).toBeGreaterThan(0);
+  });
+
+  // Scroll down in tmux = finger moves up = SGR button 65
+  test('swipe up sends scroll-down SGR sequences', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    clearMessages(sent);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Finger moves UP by 60px
+    await dispatchTouchSequence(page, {
+      points: [
+        [cx, cy],
+        [cx, cy - 20],
+        [cx, cy - 40],
+        [cx, cy - 60],
+      ],
+    });
+
+    await waitForMessages(page, 300);
+
+    // Finger moved up → startY - currentY > 0 → button 65 (scroll down/forward)
+    const scrollDowns = sent.filter((m) => m === '\x1b[<65;1;1M');
+    expect(scrollDowns.length).toBeGreaterThan(0);
+  });
+
+  test('small move (<15px) does not trigger scroll', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    clearMessages(sent);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Move only 10px — below 15px threshold
+    await dispatchTouchSequence(page, {
+      points: [
+        [cx, cy],
+        [cx, cy - 10],
+      ],
+    });
+
+    await waitForMessages(page, 300);
+
+    const scrollMsgs = sent.filter((m) => m.includes('\x1b[<64;') || m.includes('\x1b[<65;'));
+    expect(scrollMsgs.length).toBe(0);
+  });
+
+  test('accumulator: 40px swipe with 20px sensitivity = 2 events', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    clearMessages(sent);
+
+    const { cx, cy } = await getTerminalCenter(page);
+
+    // Move up 40px in one big step (past 15px threshold + 40px delta)
+    await dispatchTouchSequence(page, {
+      points: [
+        [cx, cy],
+        [cx, cy - 40],
+      ],
+    });
+
+    await waitForMessages(page, 300);
+
+    // 40px / 20px sensitivity = 2 scroll events
+    const scrollMsgs = sent.filter((m) => m === '\x1b[<65;1;1M');
+    expect(scrollMsgs.length).toBe(2);
+  });
+});

--- a/tests/mobile/virtual-keyboard.spec.ts
+++ b/tests/mobile/virtual-keyboard.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+} from '../helpers/terminal';
+
+test.describe('Virtual keyboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('hidden by default', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    await expect(page.locator('text=Virtual Keyboard')).toBeHidden();
+  });
+
+  test('toggle shows/hides panel', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    // Show
+    await page.locator('button[title="Show keyboard"]').click();
+    await expect(page.locator('text=Virtual Keyboard')).toBeVisible();
+
+    // Hide via X button
+    await page.locator('button[title="Hide keyboard"]').click();
+    await expect(page.locator('text=Virtual Keyboard')).toBeHidden();
+  });
+
+  test('all 7 sections render', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    const sections = [
+      'Quick Access', 'Line Edit', 'Claude Code',
+      'Navigate', 'Page', 'Alt Keys', 'Symbols',
+    ];
+    for (const s of sections) {
+      await expect(page.locator(`text=${s}`).first()).toBeVisible();
+    }
+  });
+
+  test('tap ^C sends \\x03', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    clearMessages(sent);
+    await page.locator('button[title="Interrupt"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x03');
+  });
+
+  test('tap Tab sends \\t', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    clearMessages(sent);
+    // Use title to avoid matching "S+Tab"
+    await page.locator('button[title="Tab/Autocomplete"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('\t');
+  });
+
+  test('tap Esc sends \\x1b', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    clearMessages(sent);
+    await page.locator('button[title="Escape/Cancel"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x1b');
+  });
+
+  test('tap ^D sends \\x04', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    clearMessages(sent);
+    await page.locator('button[title="Exit session"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('\x04');
+  });
+
+  test('tap / sends /', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+    await page.locator('button[title="Show keyboard"]').click();
+
+    clearMessages(sent);
+    await page.locator('button[title="Command"]').click();
+    await waitForMessages(page);
+
+    expect(sent).toContain('/');
+  });
+
+  test('hidden on desktop viewport', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'Desktop only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    // The bottom bar (which contains the keyboard toggle) should be hidden
+    const bottomBar = page.locator('div.md\\:hidden.h-11');
+    await expect(bottomBar).toBeHidden();
+  });
+});

--- a/tests/mobile/voice-compose.spec.ts
+++ b/tests/mobile/voice-compose.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupTerminalMocks,
+  openTerminalSession,
+  waitForMessages,
+  clearMessages,
+  stubBrowserAPIs,
+  pointerDown,
+} from '../helpers/terminal';
+
+test.describe('Voice compose overlay', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubBrowserAPIs(page);
+  });
+
+  test('tap mic opens compose overlay', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    await pointerDown(page, 'button[title="Voice input"]');
+    await waitForMessages(page, 300);
+
+    // Compose overlay has a textarea with placeholder "Speak or type..."
+    await expect(page.locator('textarea[placeholder="Speak or type..."]')).toBeVisible();
+    // And Send/Cancel buttons
+    await expect(page.locator('button:has-text("Send")')).toBeVisible();
+    await expect(page.locator('button:has-text("Cancel")')).toBeVisible();
+  });
+
+  test('type text + Send → WS receives text\\r, overlay closes', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    // Open compose
+    await pointerDown(page, 'button[title="Voice input"]');
+    await waitForMessages(page, 300);
+
+    // Type in textarea
+    const textarea = page.locator('textarea[placeholder="Speak or type..."]');
+    await textarea.fill('test');
+
+    clearMessages(sent);
+    await page.locator('button:has-text("Send")').click();
+    await waitForMessages(page, 300);
+
+    expect(sent).toContain('test\r');
+
+    // Overlay should be gone
+    await expect(textarea).toBeHidden();
+  });
+
+  test('Cancel → overlay closes, nothing sent', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    await pointerDown(page, 'button[title="Voice input"]');
+    await waitForMessages(page, 300);
+
+    const textarea = page.locator('textarea[placeholder="Speak or type..."]');
+    await textarea.fill('should not send');
+
+    clearMessages(sent);
+    await page.locator('button:has-text("Cancel")').click();
+    await waitForMessages(page, 300);
+
+    // Nothing sent
+    expect(sent.filter((m) => m.includes('should not send'))).toHaveLength(0);
+
+    // Overlay closed
+    await expect(textarea).toBeHidden();
+  });
+
+  test('Send with empty text → nothing sent', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
+    const sent = await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    await pointerDown(page, 'button[title="Voice input"]');
+    await waitForMessages(page, 300);
+
+    clearMessages(sent);
+    // Don't type anything, just hit Send
+    await page.locator('button:has-text("Send")').click();
+    await waitForMessages(page, 300);
+
+    // No message containing \r should have been sent (except potentially from init)
+    expect(sent.filter((m) => m.includes('\r'))).toHaveLength(0);
+  });
+
+  test('hidden on desktop viewport', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'Desktop only');
+    await setupTerminalMocks(page);
+    await openTerminalSession(page);
+
+    // The bottom bar (with mic button) should not be visible on desktop
+    const bottomBar = page.locator('div.md\\:hidden.h-11');
+    await expect(bottomBar).toBeHidden();
+  });
+});

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './mobile',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  retries: 1,
+  workers: undefined, // auto
+  reporter: 'list',
+
+  use: {
+    baseURL: 'http://localhost:3101',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'mobile-webkit',
+      use: {
+        ...devices['iPhone 14'],
+        // Force WebKit for iOS-accurate testing
+        browserName: 'webkit',
+      },
+    },
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        browserName: 'chromium',
+      },
+    },
+  ],
+
+  // Dev server started by the test runner
+  webServer: {
+    command: 'npm run dev',
+    port: 3101,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add 7 Playwright spec files (38 tests) covering all mobile terminal interactions: bottom bar buttons, touch scroll, virtual keyboard, paste, long-press selection, voice compose, and scroll FABs
- WebKit-compatible test helpers with mocked WebSocket/API — no tmux or server needed
- Fix unhandled promise rejection in TerminalView cleanup (`cleanup.then().catch()`)

## Test Plan
- `npx playwright test --config tests/playwright.config.ts` — 38 passed, 34 skipped (desktop mobile-only), 0 failed
- Tests run against real WebKit engine (same as iOS Safari) in headless mode
- CI-safe config: `reuseExistingServer: !process.env.CI`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)