### PR TITLE
fix: mobile paste no longer triggers 'no image found' warning

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -178,11 +178,13 @@ export function TerminalView({
         wsRef.current.send(text);
         return;
       }
+      // readText() succeeded but returned empty — clipboard may have image
+      // Send Ctrl+V for Claude Code's image paste
+      wsRef.current?.send('\x16');
     } catch {
-      // clipboard access denied or empty — fall through
+      // Clipboard access denied (common on mobile Safari) — don't send Ctrl+V
+      // as that triggers Claude Code's "no image found in clipboard" warning
     }
-    // No text in clipboard — send Ctrl+V for Claude Code's image paste
-    wsRef.current?.send('\x16');
   }, []);
 
   const startListening = useCallback(async () => {

--- a/tests/mobile/paste.spec.ts
+++ b/tests/mobile/paste.spec.ts
@@ -49,10 +49,11 @@ test.describe('Paste', () => {
     expect(sent).toContain('\x16');
   });
 
-  test('clipboard permission denied → sends Ctrl+V (\\x16)', async ({ page }, testInfo) => {
+  test('clipboard permission denied → does NOT send Ctrl+V', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'mobile-webkit', 'Mobile only');
 
-    // Stub clipboard.readText to throw (simulating denied permission)
+    // Stub clipboard.readText to throw (simulating denied permission on mobile)
+    // Should not fall back to Ctrl+V — that triggers Claude Code's "no image" warning
     await page.addInitScript(() => {
       navigator.clipboard.readText = async () => {
         throw new DOMException('Clipboard access denied', 'NotAllowedError');
@@ -66,6 +67,6 @@ test.describe('Paste', () => {
     await pointerDown(page, 'button[title="Paste (Ctrl+V)"]');
     await waitForMessages(page, 500);
 
-    expect(sent).toContain('\x16');
+    expect(sent).not.toContain('\x16');
   });
 });


### PR DESCRIPTION
## Summary
- Move Ctrl+V fallback inside the try block so it only fires when `readText()` returns empty string (possible image in clipboard)
- On permission denied (common on mobile Safari), do nothing instead of sending Ctrl+V which triggers Claude Code's "no image found" warning
- Updated test to verify permission denied does NOT send Ctrl+V

## Test Plan
- All 38 Playwright tests pass (mobile-webkit + desktop-chromium)
- Verified: clipboard text → sends text (pass)
- Verified: clipboard empty → sends Ctrl+V for image paste (pass)
- Verified: permission denied → no Ctrl+V sent (pass, was previously failing)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)