### PR TITLE
fix: iOS PWA bottom bar safe area spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,10 +33,12 @@
 }
 
 @layer base {
-  /* Lock viewport — full-screen PWA should never scroll */
+  /* Lock viewport — full-screen PWA should never scroll.
+     height: 100% ensures content fills behind safe areas with viewport-fit=cover. */
   html, body {
     overflow: hidden;
     overscroll-behavior: none;
+    height: 100%;
   }
 
   body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -224,7 +224,7 @@ export default function Home() {
   );
 
   return (
-    <div className="h-dvh flex">
+    <div className="fixed inset-0 flex">
       {/* Desktop sidebar — always visible */}
       <div className="hidden md:flex md:flex-col md:w-56 md:shrink-0 bg-surface border-r border-border">
         {sidebar}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -945,8 +945,8 @@ export function TerminalView({
               </div>
             ))}
           </div>
-          {/* Safe area bleed */}
-          <div style={{ height: 'env(safe-area-inset-bottom)' }} />
+          {/* Safe area bleed — half-height, terminal bg so it blends in */}
+          <div style={{ height: 'calc(env(safe-area-inset-bottom) / 2)', backgroundColor: XTERM_THEMES[theme].background }} />
         </div>
       )}
 
@@ -993,16 +993,21 @@ export function TerminalView({
               </button>
             </div>
           </div>
-          {/* Safe area bleed */}
-          <div style={{ height: 'env(safe-area-inset-bottom)' }} />
+          {/* Safe area bleed — half-height, terminal bg so it blends in */}
+          <div style={{ height: 'calc(env(safe-area-inset-bottom) / 2)', backgroundColor: XTERM_THEMES[theme].background }} />
         </div>
       )}
 
       {/* Bottom bar - Mobile only: scrollable strip, ordered by frequency of use.
           Esc + Enter always visible; scroll right for Paste, Attach, Mic, etc.
-          Two-zone layout: buttons row above + safe area bleed below (matches native iOS toolbar pattern). */}
-      <div className="shrink-0 md:hidden bg-gray-900 border-t border-gray-700/50 flex flex-col">
+          Safe area padding keeps buttons above the home indicator; terminal bg makes bleed invisible. */}
       <div
+        className="shrink-0 md:hidden"
+        style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) / 2)', backgroundColor: XTERM_THEMES[theme].background }}
+      >
+        {/* Visible bar — gray background with border */}
+        <div className="bg-gray-900 border-t border-gray-700/50">
+          <div
         className="flex items-center overflow-x-auto gap-1 px-2"
         style={{ scrollbarWidth: 'none' } as React.CSSProperties}
       >
@@ -1134,9 +1139,8 @@ export function TerminalView({
             <path d="M8 4h8M8 20h8" />
           </svg>
         </button>
-      </div>
-      {/* Safe area bleed — background color fills home indicator zone, no interactive content */}
-      <div className="bg-gray-900" style={{ height: 'env(safe-area-inset-bottom)' }} />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Container**: `h-dvh` → `fixed inset-0` to fill entire screen including behind safe areas
- **Bottom bar**: Replace separate bleed div with `paddingBottom: calc(env(safe-area-inset-bottom) / 2)` using terminal background color so bleed zone is invisible
- **Consistency**: All three mobile overlays (keyboard, compose, bottom bar) now use the same half-height safe area strategy

## Test Plan
- [x] 11/11 WDIO iOS PWA UX tests pass on iPhone 17 Pro simulator
- [x] Bottom bar has 0px wasted space in Safari browser mode (safe area = 0)
- [x] Architecture and code standards review completed
- [ ] Manual verification in PWA standalone mode on real iPhone

Closes #46