### PR TITLE
fix: prevent server hang from unsafe PTY FD closing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "next": "^15.1.0",
-        "node-pty": "^1.0.0",
+        "node-pty": "^1.2.0-beta.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "web-push": "^3.6.7",
@@ -6355,9 +6355,9 @@
       "license": "MIT"
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.11",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.11.tgz",
+      "integrity": "sha512-THcUyu1WwdgoIyUvgXOZ70EOMXzheGa0q3tbEb5kUIfKgcpBJ+AJ9Q1kq0bKtYmQzr77usXiTORZTLmAUQlnoQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "next": "^15.1.0",
-    "node-pty": "^1.0.0",
+    "node-pty": "^1.2.0-beta.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "web-push": "^3.6.7",


### PR DESCRIPTION
## Summary
- Upgrade node-pty from 1.1.0 to 1.2.0-beta.11 which fixes the upstream ptmx FD leak (off-by-one in `pty_posix_spawn`, PR #882)
- Remove the dangerous `closeSync(_fd - 1)` heuristic that could close kqueue/socket FDs, killing the Node.js event loop after prolonged uptime
- Replace synchronous `execFileSync` tmux session check with async `execFile` to avoid blocking the event loop on every WebSocket connection
- Remove undocumented `ptyProcess.destroy()` call — `kill()` alone is sufficient for tmux attach sessions

## Test Plan
- [x] Production build passes clean (no TS errors, no warnings)
- [x] node-pty 1.2.0-beta.11 loads and spawns PTY processes correctly
- [x] Postinstall `chmod` for spawn-helper still works with new prebuilds path
- [ ] Manual: restart server with `wormhole restart`, verify sessions connect from browser/phone
- [ ] Manual: monitor FD count after extended uptime (`lsof -p <pid> | grep ptmx | wc -l`)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)