### PR TITLE
feat: session recovery — persist and restore sessions like Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.5.0] - 2026-04-08
+
+### Features
+
+- feat: session recovery — persist all active tmux/Claude sessions to `~/.wormhole/sessions.json` and restore them on page load like Chrome tabs
+- feat: new `src/lib/sessions.ts` persistence layer — read/write/sync/remove/rename/resurrect with a single-writer model (server-side only)
+- feat: 1-minute server-side session sync interval (`server.ts`)
+- feat: `GET /api/sessions` merges live sessions with the saved file and auto-resurrects dead-but-recently-seen ones via `cld --resume`
+- feat: `DELETE` and `PATCH /api/sessions` handlers update `sessions.json` (remove on kill, rename key)
+- feat: auto-open saved tabs on page load with `?session=X` URL param precedence
+- feat: `restoring` state in `TerminalView` — shows a "Restoring session..." indicator and polls `claudeState` before opening the WebSocket, so the terminal doesn't attach to a half-started Claude
+
+### Bug Fixes
+
+- fix: recover from WebGL context loss and refresh on visibility change (#54)
+- fix: poll for `claudeState` before connecting restored-session WebSocket (avoids blank pane races)
+- fix: review round — `workingDir` validation, `claudeSessionId` injection guard, in-memory resurrection mutex, safer JSON serialization
+
+### Chores
+
+- chore: remove `tmux-resurrect` + `tmux-continuum` plugins from `scripts/tmux.conf` — session persistence is now owned by claude-wormhole itself, and the plugins were restoring dead `detached-run-claude-*` husks as interactive `cld` shells
+
 ## [1.3.0] - 2026-03-28
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ claude-wormhole/
 ├── src/app/                  # Next.js pages (session list, terminal)
 ├── public/                   # PWA manifest + icons
 ├── scripts/
-│   ├── tmux.conf             # tmux config with resurrect + continuum
+│   ├── tmux.conf             # tmux config (mouse, WheelUpPane override, TPM)
 │   ├── com.claude-wormhole.web.plist  # launchd plist
 │   └── statusline-test.sh    # Test harness for statusline
 ├── docs/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-wormhole-web",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true",

--- a/scripts/tmux.conf
+++ b/scripts/tmux.conf
@@ -1,15 +1,13 @@
 # Plugins
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 
-# Resurrect settings
-set -g @resurrect-capture-pane-contents 'on'
-set -g @resurrect-strategy-nvim 'session'
-
-# Continuum settings
-set -g @continuum-restore 'on'
-set -g @continuum-save-interval '15'
+# Session persistence is handled by claude-wormhole itself (see
+# ~/.wormhole/sessions.json and the session-recovery feature). We used to
+# rely on tmux-resurrect + tmux-continuum here, but they kept restoring
+# dead `detached-run-claude-*` husks from the run-detached skill and
+# respawning them as interactive `cld` shells, which polluted the session
+# list and broke run-detached's poll loop. Wormhole's own save/restore
+# covers the reboot use case, so resurrect is removed entirely.
 
 # Terminal capabilities — tmux-256color advertises modern Unicode/truecolor
 set -g default-terminal "tmux-256color"

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 import { execFile, execFileSync } from 'child_process';
 import { promisify } from 'util';
 import next from 'next';
+import { syncSessionsFile } from './src/lib/sessions';
 import { WebSocketServer, WebSocket } from 'ws';
 
 const dev = process.env.NODE_ENV !== 'production';
@@ -247,5 +248,15 @@ app.prepare().then(() => {
 
   server.listen(port, hostname, () => {
     console.log(`> claude-wormhole ready on http://${hostname}:${port}`);
+    // Sync active sessions to ~/.wormhole/sessions.json every 60s.
+    // Run immediately on startup to capture current state, then repeat.
+    syncSessionsFile().catch((err: unknown) => {
+      console.error('[sync] initial sync failed:', err instanceof Error ? err.message : err);
+    });
+    setInterval(() => {
+      syncSessionsFile().catch((err: unknown) => {
+        console.error('[sync] failed:', err instanceof Error ? err.message : err);
+      });
+    }, 60_000);
   });
 });

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,9 +1,54 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { listSessionsWithInfo, newSession, killSession, renameSession, restartClaudeSession } from '@/lib/tmux';
-import { removeSavedSession, renameSavedSession } from '@/lib/sessions';
+import { removeSavedSession, renameSavedSession, readSavedSessions, resurrectSession } from '@/lib/sessions';
 
 export async function GET() {
-  const sessions = await listSessionsWithInfo();
+  const [sessions, saved] = await Promise.all([
+    listSessionsWithInfo(),
+    Promise.resolve(readSavedSessions()),
+  ]);
+
+  const liveNames = new Set(sessions.map((s) => s.name));
+
+  // Mark live sessions that are in the saved file
+  for (const s of sessions) {
+    if (saved[s.name]) {
+      s.saved = true;
+    }
+  }
+
+  // Resurrect dead sessions that are in the saved file
+  const resurrectPromises: Promise<void>[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const STALE_SECONDS = 7 * 24 * 60 * 60;
+
+  for (const [name, entry] of Object.entries(saved)) {
+    if (liveNames.has(name)) continue;
+    // Skip stale entries
+    if (entry.lastSeen < now - STALE_SECONDS) continue;
+
+    resurrectPromises.push(
+      resurrectSession(name, entry).then((ok) => {
+        if (ok) {
+          sessions.push({
+            name,
+            windows: 1,
+            attached: false,
+            created: new Date().toLocaleString(),
+            workingDir: entry.workingDir,
+            lastActivity: 'just now',
+            claudeState: null,
+            saved: true,
+            restored: true,
+            restoring: !!entry.claudeSessionId,
+          });
+        }
+      })
+    );
+  }
+
+  await Promise.all(resurrectPromises);
+
   return NextResponse.json(sessions);
 }
 

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { listSessionsWithInfo, newSession, killSession, renameSession, restartClaudeSession } from '@/lib/tmux';
+import { removeSavedSession, renameSavedSession } from '@/lib/sessions';
 
 export async function GET() {
   const sessions = await listSessionsWithInfo();
@@ -46,6 +47,7 @@ export async function PATCH(req: NextRequest) {
   }
   try {
     await renameSession(oldName, newName);
+    renameSavedSession(oldName, newName);
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Failed to rename session';
@@ -60,6 +62,7 @@ export async function DELETE(req: NextRequest) {
   }
   try {
     await killSession(name);
+    removeSavedSession(name);
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Failed to kill session';

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,55 +1,54 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { listSessionsWithInfo, newSession, killSession, renameSession, restartClaudeSession } from '@/lib/tmux';
-import { removeSavedSession, renameSavedSession, readSavedSessions, resurrectSession } from '@/lib/sessions';
+import { removeSavedSession, renameSavedSession, readSavedSessions, resurrectSession, STALE_SECONDS } from '@/lib/sessions';
 
 export async function GET() {
-  const [sessions, saved] = await Promise.all([
-    listSessionsWithInfo(),
-    Promise.resolve(readSavedSessions()),
-  ]);
+  try {
+    const [sessions, saved] = await Promise.all([
+      listSessionsWithInfo(),
+      Promise.resolve(readSavedSessions()),
+    ]);
 
-  const liveNames = new Set(sessions.map((s) => s.name));
+    const liveNames = new Set(sessions.map((s) => s.name));
 
-  // Mark live sessions that are in the saved file
-  for (const s of sessions) {
-    if (saved[s.name]) {
-      s.saved = true;
+    // Mark live sessions that are in the saved file
+    for (const s of sessions) {
+      if (saved[s.name]) {
+        s.saved = true;
+      }
     }
+
+    // Resurrect dead sessions that are in the saved file.
+    // Fire-and-forget — don't block the response on resurrection completing.
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const [name, entry] of Object.entries(saved)) {
+      if (liveNames.has(name)) continue;
+      if (entry.lastSeen < now - STALE_SECONDS) continue;
+
+      // Launch resurrection in background (mutex prevents double-spawn)
+      resurrectSession(name, entry).catch(() => {});
+
+      // Include in response immediately so frontend opens the tab
+      sessions.push({
+        name,
+        windows: 1,
+        attached: false,
+        created: new Date().toLocaleString(),
+        workingDir: entry.workingDir,
+        lastActivity: 'just now',
+        claudeState: null,
+        saved: true,
+        restored: true,
+        restoring: !!entry.claudeSessionId,
+      });
+    }
+
+    return NextResponse.json(sessions);
+  } catch {
+    // Graceful fallback — return empty list so frontend doesn't crash
+    return NextResponse.json([]);
   }
-
-  // Resurrect dead sessions that are in the saved file
-  const resurrectPromises: Promise<void>[] = [];
-  const now = Math.floor(Date.now() / 1000);
-  const STALE_SECONDS = 7 * 24 * 60 * 60;
-
-  for (const [name, entry] of Object.entries(saved)) {
-    if (liveNames.has(name)) continue;
-    // Skip stale entries
-    if (entry.lastSeen < now - STALE_SECONDS) continue;
-
-    resurrectPromises.push(
-      resurrectSession(name, entry).then((ok) => {
-        if (ok) {
-          sessions.push({
-            name,
-            windows: 1,
-            attached: false,
-            created: new Date().toLocaleString(),
-            workingDir: entry.workingDir,
-            lastActivity: 'just now',
-            claudeState: null,
-            saved: true,
-            restored: true,
-            restoring: !!entry.claudeSessionId,
-          });
-        }
-      })
-    );
-  }
-
-  await Promise.all(resurrectPromises);
-
-  return NextResponse.json(sessions);
 }
 
 export async function POST(req: NextRequest) {
@@ -92,7 +91,7 @@ export async function PATCH(req: NextRequest) {
   }
   try {
     await renameSession(oldName, newName);
-    renameSavedSession(oldName, newName);
+    await renameSavedSession(oldName, newName);
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Failed to rename session';
@@ -107,7 +106,7 @@ export async function DELETE(req: NextRequest) {
   }
   try {
     await killSession(name);
-    removeSavedSession(name);
+    await removeSavedSession(name);
     return NextResponse.json({ ok: true });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Failed to kill session';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,9 @@ export default function Home() {
     // Fetch sessions and auto-open saved ones
     fetch('/api/sessions')
       .then((r) => r.json())
-      .then((sessions: Array<{ name: string; saved?: boolean; restoring?: boolean }>) => {
+      .then((data: unknown) => {
+        if (!Array.isArray(data)) return;
+        const sessions = data as Array<{ name: string; saved?: boolean; restoring?: boolean }>;
         const savedNames = sessions
           .filter((s) => s.saved)
           .map((s) => s.name);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,7 @@ export default function Home() {
   const { theme, toggle: toggleTheme } = useTheme();
   const viewport = useViewport();
   const [showIOSHint, setShowIOSHint] = useState(false);
+  const [restoringSet, setRestoringSet] = useState<Set<string>>(new Set());
 
   // Pull-to-refresh for mobile session list
   const [pullDistance, setPullDistance] = useState(0);
@@ -113,14 +114,49 @@ export default function Home() {
     };
   }, []);
 
-  // Sync URL → session on mount
+  // Restore saved sessions on mount
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const session = params.get('session');
-    if (session) {
-      setOpenTabs((prev) => (prev.includes(session) ? prev : [...prev, session]));
-      setActiveTab(session);
-    }
+    const urlSession = params.get('session');
+
+    // Fetch sessions and auto-open saved ones
+    fetch('/api/sessions')
+      .then((r) => r.json())
+      .then((sessions: Array<{ name: string; saved?: boolean; restoring?: boolean }>) => {
+        const savedNames = sessions
+          .filter((s) => s.saved)
+          .map((s) => s.name);
+
+        const restoringNames = sessions
+          .filter((s) => s.restoring)
+          .map((s) => s.name);
+        setRestoringSet(new Set(restoringNames));
+
+        if (savedNames.length > 0) {
+          setOpenTabs(savedNames);
+          // URL param takes precedence for active tab
+          if (urlSession && savedNames.includes(urlSession)) {
+            setActiveTab(urlSession);
+          } else if (urlSession) {
+            // URL session not in saved set — add it
+            setOpenTabs((prev) => prev.includes(urlSession) ? prev : [...prev, urlSession]);
+            setActiveTab(urlSession);
+          } else {
+            setActiveTab(savedNames[0]);
+          }
+        } else if (urlSession) {
+          // No saved sessions, but URL has a session param
+          setOpenTabs((prev) => prev.includes(urlSession) ? prev : [...prev, urlSession]);
+          setActiveTab(urlSession);
+        }
+      })
+      .catch(() => {
+        // Fallback: just use URL param like before
+        if (urlSession) {
+          setOpenTabs((prev) => prev.includes(urlSession) ? prev : [...prev, urlSession]);
+          setActiveTab(urlSession);
+        }
+      });
   }, []);
 
   // Sync session → URL when activeTab changes

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -328,6 +328,7 @@ export default function Home() {
               session={name}
               visible={name === activeTab}
               theme={theme}
+              restoring={restoringSet.has(name)}
               onDisconnect={() => detachSession(name)}
             />
           ))

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -128,11 +128,13 @@ export function TerminalView({
   session,
   visible,
   theme,
+  restoring,
   onDisconnect,
 }: {
   session: string;
   visible: boolean;
   theme: Theme;
+  restoring?: boolean;
   onDisconnect: () => void;
 }) {
   const termRef = useRef<HTMLDivElement>(null);
@@ -232,6 +234,8 @@ export function TerminalView({
       openComposeForPaste();
     }
   }, [openComposeForPaste]);
+
+  const [waitingForSession, setWaitingForSession] = useState(!!restoring);
 
   // File attach: opens native file picker directly.
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -478,7 +482,38 @@ export function TerminalView({
     }
   }, [visible]);
 
+  // When restoring, poll until tmux session is live before connecting WebSocket
   useEffect(() => {
+    if (!restoring) return;
+    setWaitingForSession(true);
+
+    let cancelled = false;
+    const poll = async () => {
+      while (!cancelled) {
+        try {
+          const res = await fetch('/api/sessions');
+          const sessions: Array<{ name: string }> = await res.json();
+          if (sessions.find((s) => s.name === session)) {
+            setWaitingForSession(false);
+            return;
+          }
+        } catch { /* retry */ }
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    };
+    poll();
+    // Timeout — stop waiting after 60s
+    const timeout = setTimeout(() => {
+      cancelled = true;
+      setWaitingForSession(false);
+    }, 60_000);
+
+    return () => { cancelled = true; clearTimeout(timeout); };
+  }, [restoring, session]);
+
+  useEffect(() => {
+    if (waitingForSession) return;
+
     let disposed = false;
     intentionalCloseRef.current = false;
 
@@ -862,7 +897,7 @@ export function TerminalView({
     };
     // theme intentionally excluded — handled by separate effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session]);
+  }, [session, waitingForSession]);
 
   function handleMobileKey(key: string) {
     sendKey(key);
@@ -878,6 +913,14 @@ export function TerminalView({
         backgroundColor: XTERM_THEMES[theme].background,
       }}
     >
+      {waitingForSession && visible && (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin w-6 h-6 border-2 border-muted border-t-primary rounded-full mx-auto mb-3" />
+            <p className="text-sm text-muted">Restoring session...</p>
+          </div>
+        </div>
+      )}
       {/* Terminal + reconnect overlay */}
       <div
         className="flex-1 overflow-hidden relative"

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -482,7 +482,8 @@ export function TerminalView({
     }
   }, [visible]);
 
-  // When restoring, poll until tmux session is live before connecting WebSocket
+  // When restoring, poll until Claude Code is running before connecting WebSocket.
+  // Claude's statusline hook writes claudeState — wait for it to become non-null.
   useEffect(() => {
     if (!restoring) return;
     setWaitingForSession(true);
@@ -492,8 +493,10 @@ export function TerminalView({
       while (!cancelled) {
         try {
           const res = await fetch('/api/sessions');
-          const sessions: Array<{ name: string }> = await res.json();
-          if (sessions.find((s) => s.name === session)) {
+          const sessions: Array<{ name: string; claudeState: string | null }> = await res.json();
+          const found = sessions.find((s) => s.name === session);
+          // Session exists AND Claude has started (claudeState written by statusline hook)
+          if (found && found.claudeState) {
             setWaitingForSession(false);
             return;
           }
@@ -502,7 +505,8 @@ export function TerminalView({
       }
     };
     poll();
-    // Timeout — stop waiting after 60s
+    // Timeout — connect anyway after 60s (Claude may not have started yet, but
+    // the tmux session is there so the WebSocket can still attach)
     const timeout = setTimeout(() => {
       cancelled = true;
       setWaitingForSession(false);

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -22,6 +22,17 @@ export const SESSIONS_FILE = join(WORMHOLE_DIR, 'sessions.json');
 const STALE_DAYS = 7;
 const STALE_SECONDS = STALE_DAYS * 24 * 60 * 60;
 const SAFE_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+export { STALE_SECONDS };
+
+// Serialize all read-modify-write cycles through a promise queue to prevent
+// lost-update races when concurrent API requests touch sessions.json.
+let writeQueue = Promise.resolve();
+function serialized<T>(fn: () => T | Promise<T>): Promise<T> {
+  const next = writeQueue.then(fn);
+  // Chain but don't propagate errors to subsequent queued operations
+  writeQueue = next.then(() => {}, () => {});
+  return next;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -70,96 +81,93 @@ export function writeSavedSessions(sessions: Record<string, SavedSession>): void
 // Sync (called every 60 s by server.ts)
 // ---------------------------------------------------------------------------
 
-export async function syncSessionsFile(): Promise<void> {
-  // 1. Get live tmux sessions
-  let liveNames: string[] = [];
-  try {
-    const { stdout } = await execFileAsync('tmux', [
-      'list-sessions',
-      '-F',
-      '#{session_name}',
-    ]);
-    liveNames = stdout.trim().split('\n').filter(Boolean);
-  } catch {
-    // tmux not running — no live sessions
-  }
-
-  const liveSet = new Set(liveNames);
-
-  // 2. Read existing persisted sessions
-  const sessions = readSavedSessions();
-  const now = Math.floor(Date.now() / 1000);
-
-  // 3. Upsert each live session
-  for (const name of liveNames) {
-    // Get current pane working directory
-    let workingDir = sessions[name]?.workingDir ?? '';
+export function syncSessionsFile(): Promise<void> {
+  return serialized(async () => {
+    // 1. Get all live tmux sessions with pane paths in a single call
+    const liveEntries: Array<{ name: string; workingDir: string }> = [];
     try {
       const { stdout } = await execFileAsync('tmux', [
-        'display-message',
-        '-p',
-        '-t',
-        name,
-        '#{pane_current_path}',
+        'list-sessions',
+        '-F',
+        '#{session_name}|#{pane_current_path}',
       ]);
-      workingDir = stdout.trim();
+      for (const line of stdout.trim().split('\n').filter(Boolean)) {
+        const sep = line.indexOf('|');
+        liveEntries.push({
+          name: line.slice(0, sep),
+          workingDir: line.slice(sep + 1),
+        });
+      }
     } catch {
-      // keep existing workingDir on error
+      // tmux not running — no live sessions
     }
 
-    // Read claudeSessionId from the statusline-hook-written temp file
-    let claudeSessionId: string | null = sessions[name]?.claudeSessionId ?? null;
-    try {
-      const id = readFileSync(`/tmp/wormhole-claude-session-${name}`, 'utf8').trim();
-      if (id) claudeSessionId = id;
-    } catch {
-      // no file yet — keep whatever was persisted
+    const liveSet = new Set(liveEntries.map((e) => e.name));
+
+    // 2. Read existing persisted sessions
+    const sessions = readSavedSessions();
+    const now = Math.floor(Date.now() / 1000);
+
+    // 3. Upsert each live session
+    for (const { name, workingDir: panePath } of liveEntries) {
+      // Read claudeSessionId from the statusline-hook-written temp file
+      let claudeSessionId: string | null = sessions[name]?.claudeSessionId ?? null;
+      try {
+        const id = readFileSync(`/tmp/wormhole-claude-session-${name}`, 'utf8').trim();
+        if (id) claudeSessionId = id;
+      } catch {
+        // no file yet — keep whatever was persisted
+      }
+
+      sessions[name] = {
+        workingDir: panePath || sessions[name]?.workingDir || '',
+        claudeSessionId,
+        lastSeen: now,
+      };
     }
 
-    sessions[name] = {
-      workingDir,
-      claudeSessionId,
-      lastSeen: now,
-    };
-  }
-
-  // 4. Prune entries that are stale AND not currently live
-  for (const [name, session] of Object.entries(sessions)) {
-    if (!liveSet.has(name) && now - session.lastSeen > STALE_SECONDS) {
-      delete sessions[name];
+    // 4. Prune entries that are stale AND not currently live
+    for (const [name, session] of Object.entries(sessions)) {
+      if (!liveSet.has(name) && now - session.lastSeen > STALE_SECONDS) {
+        delete sessions[name];
+      }
     }
-  }
 
-  // 5. Persist
-  writeSavedSessions(sessions);
+    // 5. Persist
+    writeSavedSessions(sessions);
+  });
 }
 
 // ---------------------------------------------------------------------------
 // Remove / Rename
 // ---------------------------------------------------------------------------
 
-export function removeSavedSession(name: string): void {
-  const sessions = readSavedSessions();
-  delete sessions[name];
-  writeSavedSessions(sessions);
+export function removeSavedSession(name: string): Promise<void> {
+  return serialized(() => {
+    const sessions = readSavedSessions();
+    delete sessions[name];
+    writeSavedSessions(sessions);
 
-  // Clean up associated temp files (best-effort)
-  for (const suffix of ['session', 'state']) {
-    try {
-      unlinkSync(`/tmp/wormhole-claude-${suffix}-${name}`);
-    } catch {
-      // file may not exist — ignore
+    // Clean up associated temp files (best-effort)
+    for (const suffix of ['session', 'state']) {
+      try {
+        unlinkSync(`/tmp/wormhole-claude-${suffix}-${name}`);
+      } catch {
+        // file may not exist — ignore
+      }
     }
-  }
+  });
 }
 
-export function renameSavedSession(oldName: string, newName: string): void {
-  const sessions = readSavedSessions();
-  if (!(oldName in sessions)) return;
+export function renameSavedSession(oldName: string, newName: string): Promise<void> {
+  return serialized(() => {
+    const sessions = readSavedSessions();
+    if (!(oldName in sessions)) return;
 
-  sessions[newName] = sessions[oldName];
-  delete sessions[oldName];
-  writeSavedSessions(sessions);
+    sessions[newName] = sessions[oldName];
+    delete sessions[oldName];
+    writeSavedSessions(sessions);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -21,6 +21,7 @@ export const WORMHOLE_DIR = join(homedir(), '.wormhole');
 export const SESSIONS_FILE = join(WORMHOLE_DIR, 'sessions.json');
 const STALE_DAYS = 7;
 const STALE_SECONDS = STALE_DAYS * 24 * 60 * 60;
+const SAFE_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -173,10 +174,18 @@ export async function resurrectSession(
   session: SavedSession,
 ): Promise<boolean> {
   // Prevent concurrent resurrection of the same session
-  if (resurrecting.has(name)) return false;
+  if (resurrecting.has(name)) return true; // already in progress — signal "being handled"
   resurrecting.add(name);
 
   try {
+    // Validate session name to prevent unexpected tmux behavior
+    if (!SAFE_NAME_RE.test(name)) return false;
+
+    // Validate claudeSessionId format before interpolating into shell command
+    if (session.claudeSessionId && !SAFE_NAME_RE.test(session.claudeSessionId)) {
+      session.claudeSessionId = null;
+    }
+
     // Validate working directory still exists
     if (!existsSync(session.workingDir)) {
       // Directory is gone — remove the stale entry and give up

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,0 +1,216 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import {
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  mkdirSync,
+  existsSync,
+  unlinkSync,
+} from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const WORMHOLE_DIR = join(homedir(), '.wormhole');
+export const SESSIONS_FILE = join(WORMHOLE_DIR, 'sessions.json');
+const STALE_DAYS = 7;
+const STALE_SECONDS = STALE_DAYS * 24 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SavedSession {
+  workingDir: string;
+  claudeSessionId: string | null;
+  lastSeen: number; // epoch seconds
+}
+
+interface SessionsFile {
+  version: 1;
+  sessions: Record<string, SavedSession>;
+}
+
+// ---------------------------------------------------------------------------
+// Read / Write helpers
+// ---------------------------------------------------------------------------
+
+export function readSavedSessions(): Record<string, SavedSession> {
+  try {
+    const raw = readFileSync(SESSIONS_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as SessionsFile;
+    return parsed.sessions ?? {};
+  } catch {
+    // File missing or malformed — start fresh
+    return {};
+  }
+}
+
+export function writeSavedSessions(sessions: Record<string, SavedSession>): void {
+  // Ensure the directory exists before writing
+  mkdirSync(WORMHOLE_DIR, { recursive: true });
+
+  const data: SessionsFile = { version: 1, sessions };
+  const json = JSON.stringify(data, null, 2);
+
+  // Atomic write: write to .tmp then rename so readers never see partial data
+  const tmp = SESSIONS_FILE + '.tmp';
+  writeFileSync(tmp, json, 'utf8');
+  renameSync(tmp, SESSIONS_FILE);
+}
+
+// ---------------------------------------------------------------------------
+// Sync (called every 60 s by server.ts)
+// ---------------------------------------------------------------------------
+
+export async function syncSessionsFile(): Promise<void> {
+  // 1. Get live tmux sessions
+  let liveNames: string[] = [];
+  try {
+    const { stdout } = await execFileAsync('tmux', [
+      'list-sessions',
+      '-F',
+      '#{session_name}',
+    ]);
+    liveNames = stdout.trim().split('\n').filter(Boolean);
+  } catch {
+    // tmux not running — no live sessions
+  }
+
+  const liveSet = new Set(liveNames);
+
+  // 2. Read existing persisted sessions
+  const sessions = readSavedSessions();
+  const now = Math.floor(Date.now() / 1000);
+
+  // 3. Upsert each live session
+  for (const name of liveNames) {
+    // Get current pane working directory
+    let workingDir = sessions[name]?.workingDir ?? '';
+    try {
+      const { stdout } = await execFileAsync('tmux', [
+        'display-message',
+        '-p',
+        '-t',
+        name,
+        '#{pane_current_path}',
+      ]);
+      workingDir = stdout.trim();
+    } catch {
+      // keep existing workingDir on error
+    }
+
+    // Read claudeSessionId from the statusline-hook-written temp file
+    let claudeSessionId: string | null = sessions[name]?.claudeSessionId ?? null;
+    try {
+      const id = readFileSync(`/tmp/wormhole-claude-session-${name}`, 'utf8').trim();
+      if (id) claudeSessionId = id;
+    } catch {
+      // no file yet — keep whatever was persisted
+    }
+
+    sessions[name] = {
+      workingDir,
+      claudeSessionId,
+      lastSeen: now,
+    };
+  }
+
+  // 4. Prune entries that are stale AND not currently live
+  for (const [name, session] of Object.entries(sessions)) {
+    if (!liveSet.has(name) && now - session.lastSeen > STALE_SECONDS) {
+      delete sessions[name];
+    }
+  }
+
+  // 5. Persist
+  writeSavedSessions(sessions);
+}
+
+// ---------------------------------------------------------------------------
+// Remove / Rename
+// ---------------------------------------------------------------------------
+
+export function removeSavedSession(name: string): void {
+  const sessions = readSavedSessions();
+  delete sessions[name];
+  writeSavedSessions(sessions);
+
+  // Clean up associated temp files (best-effort)
+  for (const suffix of ['session', 'state']) {
+    try {
+      unlinkSync(`/tmp/wormhole-claude-${suffix}-${name}`);
+    } catch {
+      // file may not exist — ignore
+    }
+  }
+}
+
+export function renameSavedSession(oldName: string, newName: string): void {
+  const sessions = readSavedSessions();
+  if (!(oldName in sessions)) return;
+
+  sessions[newName] = sessions[oldName];
+  delete sessions[oldName];
+  writeSavedSessions(sessions);
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect a dead tmux session
+// ---------------------------------------------------------------------------
+
+// In-memory mutex: names currently being resurrected
+const resurrecting = new Set<string>();
+
+export async function resurrectSession(
+  name: string,
+  session: SavedSession,
+): Promise<boolean> {
+  // Prevent concurrent resurrection of the same session
+  if (resurrecting.has(name)) return false;
+  resurrecting.add(name);
+
+  try {
+    // Validate working directory still exists
+    if (!existsSync(session.workingDir)) {
+      // Directory is gone — remove the stale entry and give up
+      removeSavedSession(name);
+      return false;
+    }
+
+    // Create a new detached tmux session rooted at the original working dir
+    await execFileAsync('tmux', [
+      'new-session',
+      '-d',
+      '-s',
+      name,
+      '-c',
+      session.workingDir,
+    ]);
+
+    // Launch Claude Code inside the session
+    const cldCmd = session.claudeSessionId
+      ? `cld --resume ${session.claudeSessionId}`
+      : 'cld';
+
+    await execFileAsync('tmux', [
+      'send-keys',
+      '-t',
+      name,
+      cldCmd,
+      'Enter',
+    ]);
+
+    return true;
+  } catch {
+    return false;
+  } finally {
+    resurrecting.delete(name);
+  }
+}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -24,6 +24,9 @@ export interface SessionInfo {
   workingDir: string;
   lastActivity: string;
   claudeState: ClaudeState;
+  saved?: boolean;      // was in sessions.json (auto-open on frontend)
+  restored?: boolean;   // was dead, just resurrected
+  restoring?: boolean;  // Claude Code is starting up
 }
 
 export async function listSessionsWithInfo(): Promise<SessionInfo[]> {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -142,6 +142,11 @@ export async function restartClaudeSession(name: string): Promise<void> {
     throw new Error(`No Claude session ID cached for "${name}". Has the session run recently?`);
   }
 
+  // Validate session ID format to prevent command injection via tampered /tmp/ files
+  if (!/^[a-zA-Z0-9_-]+$/.test(claudeSessionId)) {
+    throw new Error(`Invalid Claude session ID format for "${name}"`);
+  }
+
   // Send /exit + Enter to quit the running Claude Code process
   await execFileAsync('tmux', ['send-keys', '-t', name, '/exit', 'Enter']);
 


### PR DESCRIPTION
## Summary

- Persist all active tmux/Claude sessions to `~/.wormhole/sessions.json` via a 1-minute server-side sync
- On page load, auto-open all saved sessions as tabs — resurrecting dead tmux sessions with `cld --resume`
- Show "Restoring session..." indicator while Claude Code starts up in resurrected sessions
- Kill removes from JSON + cleans `/tmp/` cache files; rename updates key; 7-day staleness TTL prunes old entries

## Architecture

- **Single writer**: only the Node.js server writes `sessions.json` (no bash hook writes = no race conditions)
- **In-memory mutex** prevents double resurrection from concurrent browser tabs
- **`workingDir` validation** skips resurrection if directory was deleted
- **`claudeSessionId` validation** prevents injection via tampered cache files

## Files changed

| File | What |
|------|------|
| `src/lib/sessions.ts` | New — persistence layer (read/write/sync/remove/rename/resurrect) |
| `server.ts` | 1-minute sync interval |
| `src/app/api/sessions/route.ts` | GET: merge + resurrect. DELETE: cleanup. PATCH: rename |
| `src/app/page.tsx` | Auto-open saved tabs, `?session=X` precedence |
| `src/components/TerminalView.tsx` | Restoring indicator, polls claudeState before WS connect |
| `src/lib/tmux.ts` | Added saved/restored/restoring fields to SessionInfo |

## Test plan

- [ ] Server starts, sync creates `~/.wormhole/sessions.json` with live sessions
- [ ] Page reload auto-opens previously active sessions
- [ ] Kill session via UI removes it from JSON and `/tmp/` files
- [ ] Rename session updates key in JSON
- [ ] After machine reboot, page load resurrects saved sessions with `cld --resume`
- [ ] "Restoring session..." spinner shows during resurrection
- [ ] `?session=X` URL param sets active tab while still opening all saved tabs
- [ ] Sessions older than 7 days are pruned and not resurrected
- [ ] Missing `workingDir` causes session to be skipped and removed from JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)